### PR TITLE
Expose ports without publishing them to the host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,9 @@ version: '3'
 services:
   db:
     image: postgres:10.3
-    ports:
-      - 5432:5432
 
   redis:
     image: redis:4.0
-    ports:
-      - 6379:6379
 
   sidekiq:
     image: hackaru/hackaru-api:1


### PR DESCRIPTION
Expose postgres and redis ports without publishing them to the host machine. They will be only to the linked services.
This prevents you from accidentially opening your postgres and redis instance to the internet.